### PR TITLE
Fixing build error

### DIFF
--- a/lib/cocoa.rb
+++ b/lib/cocoa.rb
@@ -24,9 +24,9 @@ Motion::Project::App.setup do |app|
 
   samples = %w(android ios osx).delete_if {|t| t == template}
   samples.each do |sample|
-    app.files.delete_if { |path| path.start_with?("./app/#{sample}") }
+    app.files.delete_if { |path| path.start_with?("./app/#{sample}") if path.is_a?(String)}
   end
-  app.spec_files.delete_if { |path| path.start_with?('./spec/helpers/android') }
+  app.spec_files.delete_if { |path| path.start_with?('./spec/helpers/android') if path.is_a?(String)}
 
   app.frameworks += ['SystemConfiguration', 'CoreLocation', 'AddressBookUI']
 end


### PR DESCRIPTION
rake aborted!
NoMethodError: undefined method `start_with?' for #<Array:0x007ffb81278c40>
/.rvm/gems/ruby-2.0.0-p481/bundler/gems/Flow-70322b758ce8/lib/cocoa.rb:27:in `block (3 levels) in <top (required)>'