### PR TITLE
Tell how to add Flow to project without Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ rake -T
 
 #### RubyMotion projects
 
-Flow can be added as a dependency of an existing iOS, Android or OS X RubyMotion project, by adding the `motion-flow` gem in the project's `Gemfile`.
+Flow can be added as a dependency of an existing iOS, Android or OS X RubyMotion project, by adding the `motion-flow` gem in the project's `Gemfile` assuming Bundler is being used.  If Bundler is not being used, Flow can be added as a dependency by adding `require 'motion-flow'` to the project's `Rakefile`.
 
 ## License
 


### PR DESCRIPTION
Improve the documentation for how to add FLow as a dependency of an
existing project by making it clear that adding the motion-flow gem
to the project's Gemfile works if using Bundler.  Add how to add a
dependency using the project's Rakefile if not using Bundler.
