### PR TITLE
Mention dependency on RubyMotion 4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Flow is currently composed of the following libraries:
 
 ### Installation
 
+Flow requires RubyMotion >= 4.12. To use the Android emulator, make sure to run `motion android-setup`. Next, install the gem:
+
 ```
 $ gem install motion-flow
 ```


### PR DESCRIPTION
This PR adds to the README that RubyMotion 4.12 is required to use Flow due to the bug mentioned in #13.