### PR TITLE
Fix bug in measuring size of nil label

### DIFF
--- a/flow/ui/cocoa/label.rb
+++ b/flow/ui/cocoa/label.rb
@@ -6,6 +6,7 @@ module UI
     end
 
     def measure(width, height)
+      return [0,0] if proxy.attributedText.nil? || proxy.attributedText.length == 0
       size = [width.nan? ? Float::MAX : width, Float::MAX]
       rect = proxy.attributedText.boundingRectWithSize(size, options:NSStringDrawingUsesLineFragmentOrigin, context:nil)
       [width, rect.size.height]

--- a/test/spec/ui/label.rb
+++ b/test/spec/ui/label.rb
@@ -1,0 +1,30 @@
+describe UI::Label do
+  describe "#measure" do
+    context "when text is nil" do
+      it "returns [0, 0]" do
+        label = UI::Label.new
+        label.text = nil
+        w = h = 500.0
+        label.measure(w,h).should == [0,0]
+      end
+    end
+
+    context "when text is empty" do
+      it "returns [0, 0]" do
+        label = UI::Label.new
+        label.text = ""
+        w = h = 500.0
+        label.measure(w,h).should == [0,0]
+      end
+    end
+
+    context "when text is not empty" do
+      it "returns the correct size" do
+        label = UI::Label.new
+        label.text = "Hello World"
+        w = h = 500.0
+        label.measure(w,h).should == [w, 20.287109375]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #31 by returning a size of zero when the label title is nil.
