### PR TITLE
removed direct dependency on `/usr/bin/rake`

### DIFF
--- a/lib/motion-flow.rb
+++ b/lib/motion-flow.rb
@@ -15,7 +15,7 @@ else
     trace = Rake.application.options.trace == true
 
     template = platform.to_s == 'android' ? 'android' : 'cocoa'
-    system "template=#{platform} /usr/bin/rake -r \"#{File.dirname(__FILE__)}/#{template}.rb\" -f \"config/#{platform}.rb\" \"#{task}\" #{trace ? '--trace' : ''}" or exit 1
+    system "template=#{platform} rake -r \"#{File.dirname(__FILE__)}/#{template}.rb\" -f \"config/#{platform}.rb\" \"#{task}\" #{trace ? '--trace' : ''}" or exit 1
   end
   namespace 'ios' do
     desc "Create an .ipa archive"
@@ -231,7 +231,7 @@ else
   task "super_repl" do
     require "readline"
 
-    cmd = %w{ /usr/bin/rake }
+    cmd = %w{ rake }
     ios_cmd = cmd + ['ios:simulator']
     android_cmd = cmd + ['android:emulator:start']
 


### PR DESCRIPTION
Someone using `rbenv` could run into a situation where the ruby version
they are building the app on is a different ruby version that's
installed at `/usr/bin/rake`. In my specific case, I've never updated
the default system installed `ruby`.