### PR TITLE
Bundler require statement added to ios/android/mac erb.

### DIFF
--- a/template/flow/files/config/android.rb.erb
+++ b/template/flow/files/config/android.rb.erb
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+begin
+  require 'bundler'
+  Bundler.require
+rescue LoadError
+end
+
 Motion::Project::App.setup do |app|
   # Use `rake android:config' to see complete project settings.
   app.name = '<%= name %>'

--- a/template/flow/files/config/ios.rb.erb
+++ b/template/flow/files/config/ios.rb.erb
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+begin
+  require 'bundler'
+  Bundler.require
+rescue LoadError
+end
+
 Motion::Project::App.setup do |app|
   # Use `rake ios:config' to see complete project settings.
   app.name = '<%= name %>'

--- a/template/flow/files/config/osx.rb.erb
+++ b/template/flow/files/config/osx.rb.erb
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+begin
+  require 'bundler'
+  Bundler.require
+rescue LoadError
+end
+
 Motion::Project::App.setup do |app|
   # Use `rake ios:config' to see complete project settings.
   app.name = '<%= name %>'


### PR DESCRIPTION
Why this is needed.

Per Mark:

>https://github.com/HipByte/Flow/blob/master/lib/motion-flow.rb#L18
>the rake tasks are being invoked on another spawned ruby process