### PR TITLE
Clarify which type of documentation is currently available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each library implements the following requirements:
 * 100% cross-platform (iOS, Android and OS X)
 * No external dependencies
 * Covered by tests
-* [Extensive documentation](http://www.rubymotion.com/developers/motion-flow/)
+* [API Documentation](http://www.rubymotion.com/developers/motion-flow/)
 
 **WARNING**: Flow is currently a work in progress. Some specs might be broken, APIs might change, and documentation might be missing. We are working toward a stable release. If you want to help please get in touch.
 


### PR DESCRIPTION
Let's not get ahead of ourselves. The README kind of comes across as arrogant when it says that there is "Extensive documentation" when there really isn't. This change makes it sound more professional by mentioning that the documentation available is specifically API documentation.