### PR TITLE
Don't silence load error when bundler fails to be required

### DIFF
--- a/template/flow/files/Rakefile
+++ b/template/flow/files/Rakefile
@@ -2,9 +2,10 @@
 
 begin
   require 'bundler'
-  Bundler.require
 rescue LoadError
+  raise "Could not load the bundler gem. Install it with `gem install bundler`."
 end
+Bundler.require
 
 # This file is empty on purpose, you can edit it to add your own tasks.
 # Use `rake -T' to see the list of all tasks.


### PR DESCRIPTION
If someone who is unfamiliar with Bundler does not have bundler installed, this makes it easier to find the error. This solves the issue with #8.