### PR TITLE
[Android] Maintain navigation stack correctly when hardware back button is used to pop screens

### DIFF
--- a/flow/ui/android/navigation.rb
+++ b/flow/ui/android/navigation.rb
@@ -105,8 +105,10 @@ class UI::Navigation
     else
       @current_screens.pop
       previous_screen = @current_screens.last
-      previous_screen.before_on_show
-      previous_screen.on_show
+      if previous_screen
+        previous_screen.before_on_show
+        previous_screen.on_show
+      end
     end
     @stack_change_reason = nil
   end

--- a/flow/ui/android/navigation.rb
+++ b/flow/ui/android/navigation.rb
@@ -54,6 +54,7 @@ class UI::Navigation
   end
 
   def push(screen, animated=true)
+    @stack_change_reason = :push
     screen.navigation = self
 
     fragment = screen.proxy
@@ -73,6 +74,7 @@ class UI::Navigation
 
   def pop(animated=true)
     if @current_screens.size > 1
+      @stack_change_reason = :pop
       current_screen = @current_screens.pop
       current_screen.proxy._animate = animated ? :slide : false
       previous_screen = @current_screens.last
@@ -89,6 +91,33 @@ class UI::Navigation
   end
 
   def proxy
-    @proxy ||= UI.context.fragmentManager
+    @proxy ||= begin
+      manager = UI.context.fragmentManager
+      manager.addOnBackStackChangedListener(FlowFragmentManagerStackChangedListener.new(self))
+      manager
+    end
+  end
+
+  def stack_changed
+    case @stack_change_reason
+    when :push
+    when :pop
+    else
+      @current_screens.pop
+      previous_screen = @current_screens.last
+      previous_screen.before_on_show
+      previous_screen.on_show
+    end
+    @stack_change_reason = nil
+  end
+end
+
+class FlowFragmentManagerStackChangedListener
+  def initialize(navigation)
+    @navigation = navigation
+  end
+
+  def onBackStackChanged
+    @navigation.stack_changed
   end
 end


### PR DESCRIPTION
We can enable hardware back button support by adding this to `MainActivity`:

```
  def onBackPressed
    if fragmentManager.backStackEntryCount > 0
      fragmentManager.popBackStack
    else
      super
    end
  end
```

But when we press the hardware button UI::Navigation's @current_screens isn't kept in sync, and `#before_on_show` and `#on_show` for the revealed screen isn't called like calling `#pop` does.

This commit fixes it.