### PR TITLE
fix android resources directory problem

### DIFF
--- a/lib/android.rb
+++ b/lib/android.rb
@@ -6,8 +6,6 @@ require 'motion/project/template/android'
 Motion::Project::App.setup do |app|
   app.api_version = '23' unless Motion::Project::Config.starter?
   app.build_dir = 'build/android'
-  app.assets_dirs << 'resources'
-  app.resources_dirs = []
 
   FLOW_COMPONENTS.each do |comp|
     libdir = File.join(File.dirname(__FILE__), '../flow/' + comp)


### PR DESCRIPTION
* stop adding 'resources' to app.assets_dirs otherwise my resources such as layout/ and drawable/ will be copied into apk's assets/ directory, it's no good
* stop assigning `[]` to app.resources_dirs otherwise RubyMotion's default resources_dir which is './resources' will be overridden and my resources will not copied into apk's res/ directory

I think this PR will resolve this issue https://github.com/HipByte/Flow/issues/36