### PR TITLE
[Net] application/vnd.api+json should be valid as json

### DIFF
--- a/flow/net/android/request.rb
+++ b/flow/net/android/request.rb
@@ -65,7 +65,7 @@ module Net
     end
 
     def json?
-      configuration[:headers].fetch('Content-Type', nil) == "application/json"
+      Net::MimeTypes::JSON.include?(configuration[:headers].fetch('Content-Type', nil))
     end
 
     def url_connection

--- a/flow/net/cocoa/request.rb
+++ b/flow/net/cocoa/request.rb
@@ -61,7 +61,7 @@ module Net
     end
 
     def json?
-      configuration[:headers].fetch('Content-Type', nil) == "application/json"
+      Net::MimeTypes::JSON.include?(configuration[:headers].fetch('Content-Type', nil))
     end
 
     def build_body(body)

--- a/flow/net/mime_types.rb
+++ b/flow/net/mime_types.rb
@@ -1,0 +1,8 @@
+module Net
+  module MimeTypes
+    JSON = %w(
+      application/json
+      application/vnd.api+json
+    )
+  end
+end


### PR DESCRIPTION
This solution can increase cases that work well
in my case, it became to work well with a Rails server bundled `jsonapi-resources`
refer to https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/mime_types.rb#L4