### PR TITLE
[Net] application/vnd.api+json of response should be valid as well

### DIFF
--- a/flow/net/android/response_proxy.rb
+++ b/flow/net/android/response_proxy.rb
@@ -44,7 +44,7 @@ module Net
     end
 
     def json?
-      mime_type.match /application\/json/
+      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body

--- a/flow/net/cocoa/response_proxy.rb
+++ b/flow/net/cocoa/response_proxy.rb
@@ -39,7 +39,7 @@ module Net
     end
 
     def json?
-      mime_type.match /application\/json/
+      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body


### PR DESCRIPTION
* this is a continuation of https://github.com/HipByte/Flow/pull/65 .  I should have considered also response (sorry I made pull requests separately)
* I knew why the original code was String#match because response mime_type becomes not only `application/json` but also `application/json; charset=utf-8`
* to keep source code simple, I use String#include? instead because RubyMotion's String#match does not accept String object as an argument (it seems only Regexp object can be accepted)