### PR TITLE
Net/content type application json responce proxy

### DIFF
--- a/flow/net/android/response_proxy.rb
+++ b/flow/net/android/response_proxy.rb
@@ -44,7 +44,7 @@ module Net
     end
 
     def json?
-      mime_type.match /application\/json/
+      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body

--- a/flow/net/android/response_proxy.rb
+++ b/flow/net/android/response_proxy.rb
@@ -44,7 +44,7 @@ module Net
     end
 
     def json?
-      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
+      mime_type && Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body

--- a/flow/net/cocoa/response_proxy.rb
+++ b/flow/net/cocoa/response_proxy.rb
@@ -39,7 +39,7 @@ module Net
     end
 
     def json?
-      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
+      mime_type && Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body

--- a/flow/net/cocoa/response_proxy.rb
+++ b/flow/net/cocoa/response_proxy.rb
@@ -39,7 +39,7 @@ module Net
     end
 
     def json?
-      mime_type.match /application\/json/
+      Net::MimeTypes.json.any? { |json_type| mime_type.include?(json_type) }
     end
 
     def build_body


### PR DESCRIPTION
* this is a continuation of #65 . I should have considered also response (sorry I made pull requests separately)
  * I knew why the original code was String#match because response mime_type becomes not only `application/json` but also `application/json; charset=utf-8`
  * to keep source code simple, I use String#include? instead because RubyMotion's String#match does not accept String object as an argument (it seems only Regexp object can be accepted)

* and I added judgment whether mime_type is not nil because we sometimes have API server implementation like this:
  * HTTP DELETE method returns `204 No Content`
  * it does not have payload body and mime_type becomes nil
  * as a result, both `mime_type.include?` and `mime_type.match` will raise NoMethodError when mime_type is nil
