### PR TITLE
fix android location time bug

### DIFF
--- a/flow/location/android/location_services.rb
+++ b/flow/location/android/location_services.rb
@@ -23,7 +23,7 @@ class Location
     obj.latitude = jlocation.latitude
     obj.longitude = jlocation.longitude
     obj.altitude = jlocation.altitude
-    obj.time = Time.new(jlocation.time)
+    obj.time = Time.new.setTimeInMillis(jlocation.time)
     obj.speed = jlocation.speed
     obj.accuracy = jlocation.accuracy
     obj


### PR DESCRIPTION
`Time` is a `GregorianCalendar` (https://developer.android.com/reference/java/util/GregorianCalendar.html) which doesn't seem to have a constructor with a timestamp and it was throwing an error for me. 