### PR TITLE
change string.to_data to string.dataUsingEncoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ before_install:
   - sudo mkdir -p ~/Library/RubyMotion/build
   - sudo chown -R travis ~/Library/RubyMotion/build
 script:
+  - bundle install
   - rake build:ios
-  - cd test && bundle install
+  - cd test && bundle install --gemfile=./Gemfile
   - ruby server.rb &
-  - bundle exec rake ios:clean:all
-  - bundle exec rake ios:spec
+  - rake ios:clean:all
+  - rake ios:spec

--- a/flow/base64/cocoa/base64.rb
+++ b/flow/base64/cocoa/base64.rb
@@ -1,6 +1,6 @@
 class Base64
   def self.encode(string)
-    data = string.to_data
+    data = string.dataUsingEncoding(NSUTF8StringEncoding)
     data.base64EncodedStringWithOptions(0)
   end
 

--- a/flow/digest/cocoa/digest.rb
+++ b/flow/digest/cocoa/digest.rb
@@ -5,7 +5,7 @@ module Digest
     end
 
     def update(str)
-      @digest.update(str.to_data)
+      @digest.update(str.dataUsingEncoding(NSUTF8StringEncoding))
       self
     end
 

--- a/flow/json/cocoa/json.rb
+++ b/flow/json/cocoa/json.rb
@@ -1,7 +1,7 @@
 class JSON
   def self.load(string)
     error_ptr = Pointer.new(:id)
-    obj = NSJSONSerialization.JSONObjectWithData(string.to_data, options:0, error:error_ptr)
+    obj = NSJSONSerialization.JSONObjectWithData(string.dataUsingEncoding(NSUTF8StringEncoding), options:0, error:error_ptr)
     if obj == nil
       raise error_ptr[0].description
     end

--- a/flow/net/cocoa/request.rb
+++ b/flow/net/cocoa/request.rb
@@ -65,7 +65,7 @@ module Net
     end
 
     def build_body(body)
-      (json? and body != '') ? body.to_json.to_data : body.to_data
+      (json? and body != '') ? body.to_json.dataUsingEncoding(NSUTF8StringEncoding) : body.dataUsingEncoding(NSUTF8StringEncoding)
     end
 
     def set_defaults

--- a/samples/reddit/app/post_row.rb
+++ b/samples/reddit/app/post_row.rb
@@ -15,7 +15,7 @@ class PostRow < UI::ListRow
 
     if post.thumbnail
       Net.get(post.thumbnail) do |response|
-        thumbnail.source = response.body.to_data
+        thumbnail.source = response.body.dataUsingEncoding(NSUTF8StringEncoding)
       end
     end
   end


### PR DESCRIPTION
It looks like `str.to_data` has been removed from rubymotion, so we should rather use `string.dataUsingEncoding`