### PR TITLE
Add AVFoundation to app frameworks for Cocoa

### DIFF
--- a/lib/cocoa.rb
+++ b/lib/cocoa.rb
@@ -30,5 +30,5 @@ Motion::Project::App.setup do |app|
   end
   app.spec_files.delete_if { |path| path.start_with?('./spec/helpers/android') }
 
-  app.frameworks += ['SystemConfiguration', 'CoreLocation', 'AddressBookUI']
+  app.frameworks += ['SystemConfiguration', 'CoreLocation', 'AddressBookUI', 'AVFoundation']
 end


### PR DESCRIPTION
Fixes #83.