### PR TITLE
Allow the default Android app API version to be overwritten by environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ If you are targeting Android, you need to install the dependencies with Gradle:
 $ bundle && rake android:gradle:install
 ```
 
+NOTE: The Android app API version defaults to version `"23"`.  
+To overwrite it set the environment variable `ANDROID_APP_API_VERSION` to the desired version for example:
+
+```
+echo 'export ANDROID_APP_API_VERSION="28"' >> ~/.zshrc
+```
+
 ### Projects
 
 #### Flow projects

--- a/lib/android.rb
+++ b/lib/android.rb
@@ -5,7 +5,7 @@ require 'motion/project/template/android'
 require 'motion-gradle'
 
 Motion::Project::App.setup do |app|
-  app.api_version = '23' unless Motion::Project::Config.starter?
+  app.api_version = ENV['ANDROID_APP_API_VERSION'] ||= '23' unless Motion::Project::Config.starter?
   app.build_dir = 'build/android'
   app.assets_dirs << 'resources'
   app.resources_dirs = []


### PR DESCRIPTION
The Android app API version is hardcoded to version 23.
Which forces people to install the API version 23 when they try to run any kind of rake task,  
for example `rake android:device` or even `rake android:spec` will result in:    
```
$ rake android:spec --trace

** Invoke android:spec (first_time)
** Execute android:spec
    ERROR! The Android SDK installed on your system does not support API level 23. Run 'motion android-setup --api_version=23' to install it.
```  

Allowing users to optionally overwrite this hardcoded value with an environment variable `ANDROID_APP_API_VERSION` provides a bit more flexibility.

Otherwise, it might be annoying because what if for example a user wants to set up and use API version 28 only without having to deal with version 23.

TL;DR

The optional `ANDROID_APP_API_VERSION` environment variable in this PR does not change/break the current gem behavior in any way.  
And it may not be a long term solution but It does allow for some clarity and flexibility when it comes to picking the Android API version for a project.

Please accept.

Cheers,
Khalil